### PR TITLE
Adding tag to use frontend analytics along with google analytics

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,6 +5,8 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- Self-hosted analytics tag -->
+    <script async defer data-website-id="330778e6-1290-4a4a-acd7-fb736b430e99" src="https://umami.ryanjchen.com/umami.js"></script>
         <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-121905904-2"></script>
     <script>


### PR DESCRIPTION
Deciding to use umami.js instead of Google Analytics. This PR will add both tags while I evaluate umami.js. After about a month, I will switch to umami.js full time if this goes well.